### PR TITLE
fix layout issue

### DIFF
--- a/src/_includes/chapter.liquid
+++ b/src/_includes/chapter.liquid
@@ -23,15 +23,15 @@ layout: layout
       <p class="ebook-chapter-title">{{ title }} </p>
     </div>
     <div class="ebook-copy">
-      <p class="copy-paragraph">{{ content }}</p>
+      <div class="copy-paragraph">{{ content }}</div>
     </div>
   </div>
-  <div class="ebook-image">
-    {% if image %}
+  {% if image %}
+    <div class="ebook-image">
       {% assign currentBookSlug = page.filePathStem | split: "/" | slice: 2, 1 | join: "" %}
-      <img src="/ebooks/{{ currentBookSlug }}/images/{{ image }}" alt="{{ title }}">
-    {% endif %}
-  </div>
+      <img src="/ebooks/{{ currentBookSlug }}/images/{{ image }}" alt="{{ title }}">  
+    </div>
+  {% endif %}
 </div>
 
 <div class="nav-container">

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -286,8 +286,9 @@ p {
       font-weight: bold;
     }
     .copy-paragraph {
-      font-size: 1.25em;
+      font-size: 20px;
       line-height: 2;
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
- found that using a div instead of a p for the .copy-paragraph was better because printing {{ content }} will also print a p and browsers prematurely close the first p tag
- had to adjust font-size, not sure if this breaks responsive concerns
- only include the image section if there is an image

Resolves #26