### PR TITLE
Add alt tag support in front matter

### DIFF
--- a/src/_includes/chapter.liquid
+++ b/src/_includes/chapter.liquid
@@ -29,7 +29,7 @@ layout: layout
   {% if image %}
     <div class="ebook-image">
       {% assign currentBookSlug = page.filePathStem | split: "/" | slice: 2, 1 | join: "" %}
-      <img src="/ebooks/{{ currentBookSlug }}/images/{{ image }}" alt="{{ title }}">  
+      <img src="/ebooks/{{ currentBookSlug }}/images/{{ image }}" alt="{{ image-alt }}">  
     </div>
   {% endif %}
 </div>

--- a/src/ebooks/jponch-sample/chapters/chapter-1.md
+++ b/src/ebooks/jponch-sample/chapters/chapter-1.md
@@ -1,6 +1,7 @@
 ---
 title: "Why your CMS project will fail"
 image: "Illustration.png"
+image-alt: "A man holding a CMS"
 layout: chapter
 ---
 

--- a/src/ebooks/large-team-challenges/chapters/chapter-4.md
+++ b/src/ebooks/large-team-challenges/chapters/chapter-4.md
@@ -1,6 +1,7 @@
 ---
 title: Multiple people editing the same piece of content
 image: "chapter-4.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 With idioms like “too many cooks in the kitchen,” this problem has clearly reared its ugly head for generations, even before the idea of websites was ever imagined. Now the kitchen is virtual.

--- a/src/ebooks/large-team-challenges/chapters/chapter-5.md
+++ b/src/ebooks/large-team-challenges/chapters/chapter-5.md
@@ -1,6 +1,7 @@
 ---
 title: Multiple copies of assets
 image: "chapter-5.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 

--- a/src/ebooks/large-team-challenges/chapters/chapter-6.md
+++ b/src/ebooks/large-team-challenges/chapters/chapter-6.md
@@ -1,6 +1,7 @@
 ---
 title: Editors who use the website infrequently
 image: "chapter-6.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 Some editors may only hop in every few weeks or every few months. They

--- a/src/ebooks/large-team-challenges/chapters/chapter-7.md
+++ b/src/ebooks/large-team-challenges/chapters/chapter-7.md
@@ -1,6 +1,7 @@
 ---
 title: "Workflow bottlenecks"
 image: "chapter-7.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 How many gates does a piece of content need to pass through before it gets

--- a/src/ebooks/large-team-challenges/chapters/chapter-8.md
+++ b/src/ebooks/large-team-challenges/chapters/chapter-8.md
@@ -1,6 +1,7 @@
 ---
 title: Translation drift
 image: "chapter-8.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 

--- a/src/ebooks/large-team-challenges/chapters/chapter-9.md
+++ b/src/ebooks/large-team-challenges/chapters/chapter-9.md
@@ -1,6 +1,7 @@
 ---
 title: Permissions that don’t match the requirements of your team
 image: "chapter-9.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 

--- a/src/ebooks/over-structured-content/chapters/chapter-10.md
+++ b/src/ebooks/over-structured-content/chapters/chapter-10.md
@@ -1,6 +1,7 @@
 ---
 title: "Content inventory"
 image: "page_11_image_1.jpeg"
+image-alt: "your alt text here"
 layout: chapter
 ---
 Know where you are before you try and figure out where you’re going. A content inventory can tell you how much content you are dealing with, how it’s organized, what it contains, and more. For example, you’ll be able to tell how much you rely on PDFs, if certain pages get no traffic, or if editors are cramming too much content onto a single page.

--- a/src/ebooks/over-structured-content/chapters/chapter-11.md
+++ b/src/ebooks/over-structured-content/chapters/chapter-11.md
@@ -1,6 +1,7 @@
 ---
 title: "Collaborative workshops"
 image: "page_12_image_1.jpeg"
+image-alt: "your alt text here"
 layout: chapter
 ---
 A website is a shared resource with many people involved, so you need to work together when planning how to structure your content. Priorities will clash, and you need to get those out in the open. A shared vision is required.

--- a/src/ebooks/over-structured-content/chapters/chapter-2.md
+++ b/src/ebooks/over-structured-content/chapters/chapter-2.md
@@ -1,6 +1,7 @@
 ---
 title: "Signs of over-structured content"
 image: "Title Crazy@2x.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 While structuring your content is a must for the modern web, you can go too far or even add structure to the wrong things. You want to break up your content into the smallest pieces possible but within reason. You can always distill your content down, but it’s possible to take it to absurd levels. How do you know if you’ve done this?

--- a/src/ebooks/over-structured-content/chapters/chapter-3.md
+++ b/src/ebooks/over-structured-content/chapters/chapter-3.md
@@ -1,6 +1,7 @@
 ---
 title: "Lots of documentation for seemingly simple tasks"
 image: "Over-documented@2x.jpg"
+image-alt: "your alt text here"
 layout: chapter
 ---
 

--- a/src/ebooks/over-structured-content/chapters/chapter-4.md
+++ b/src/ebooks/over-structured-content/chapters/chapter-4.md
@@ -1,6 +1,7 @@
 ---
 title: "Content is published or updated at a slower rate than desired"
 image: "Illustration - Publishing Time@2x.jpg"
+image-alt: "your alt text here"
 layout: chapter
 ---
 Once content is ready to publish, does it take a long time to finally get on the website? Longer than you think it should? There are many possible reasons for this, but one of them might be because of complications introduced by too much structure. Sometimes this is caused by performance problems from nested fields and relationships. One of our clients had to wait 20-30 seconds for a pop-up to load, and many pages required using that pop-up ten to twenty times to get ready.

--- a/src/ebooks/over-structured-content/chapters/chapter-7.md
+++ b/src/ebooks/over-structured-content/chapters/chapter-7.md
@@ -1,6 +1,7 @@
 ---
 title: "High turnover rate for editors"
 image: "Crazy Publishing Process@2x.jpg"
+image-alt: "your alt text here"
 layout: chapter
 ---
 People quit for all sorts of reasons, but if you have a high rate, you might want to dig deeper and find out why. Often, overstructured content comes with a painful UX. What was supposed to empower editors ended up as a heavy weight on their shoulders, leading to burnout.

--- a/src/ebooks/over-structured-content/chapters/chapter-9.md
+++ b/src/ebooks/over-structured-content/chapters/chapter-9.md
@@ -1,6 +1,7 @@
 ---
 title: "Stakeholder and user interviews"
 image: "page_10_image_1.jpeg"
+image-alt: "your alt text here"
 layout: chapter
 ---
 The only way to find out what will work for your organization is to talk to the people who make up your organization. And then, talk to users of your website and find out what their needs and pain points are. Remember, however, not to ignore your internal users.

--- a/src/ebooks/rogue-university/chapters/chapter-1.md
+++ b/src/ebooks/rogue-university/chapters/chapter-1.md
@@ -1,6 +1,7 @@
 ---
 title: "Introduction"
 image: "illustration_archepelago.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 

--- a/src/ebooks/rogue-university/chapters/chapter-2.md
+++ b/src/ebooks/rogue-university/chapters/chapter-2.md
@@ -1,6 +1,7 @@
 ---
 title: "Why Governing Archipelagos Can Be Challenging"
 image: "illustration_umbrella-org.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 

--- a/src/ebooks/rogue-university/chapters/chapter-3.md
+++ b/src/ebooks/rogue-university/chapters/chapter-3.md
@@ -1,6 +1,7 @@
 ---
 title: "Three Types of Archipelagos"
 image: "illustration_centralized-vs-decentralized@2x.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 

--- a/src/ebooks/rogue-university/chapters/chapter-4.md
+++ b/src/ebooks/rogue-university/chapters/chapter-4.md
@@ -1,6 +1,7 @@
 ---
 title: "The Magical Intersection of Success"
 image: "illustration_umbrella-subsidiaries-users_diagram.png"
+image-alt: "your alt text here"
 layout: chapter
 ---
 

--- a/src/ebooks/rogue-university/chapters/chapter-5.md
+++ b/src/ebooks/rogue-university/chapters/chapter-5.md
@@ -1,6 +1,7 @@
 ---
 title: "Research"
 image: "Personas@2x.jpg"
+image-alt: "your alt text here"
 layout: chapter
 ---
 


### PR DESCRIPTION
Resolves #40 

Add support in the template for image alt tags.
Add sample image-alt front matter to chapters with images.

I didn't take the time to do accurate alt text for these image since all of our books are samples and I'm not sure that we'll actually keep them or not. If we do keep them, we'll want to update the alt text to accurately describe the images.