### PR TITLE
73  short titles

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,11 +4,11 @@ const path = require("path");
 module.exports = function (eleventyConfig) {
   // Generate a collection of all books with their pages
   eleventyConfig.addCollection("booksWithPages", function (collectionApi) {
-    const books = collectionApi.getFilteredByGlob("src/ebooks/*/cover.md");
+    const books = collectionApi.getFilteredByGlob("src/ebooks/*/index.html");
     const pages = collectionApi.getFilteredByGlob("src/ebooks/*/pages/*.md");
 
     return books.map(book => {
-      const bookSlug = book.filePathStem.split("/")[2];
+      const bookSlug = book.filePathStem.split('/')[2];
       const bookPages = pages
         .filter(page => page.inputPath.includes(bookSlug))
         .sort((a, b) => {
@@ -19,8 +19,10 @@ module.exports = function (eleventyConfig) {
 
       return {
         book: {
-          ...book.data,
+          title: book.data.title,
+          shortTitle: book.data.shortTitle,
           slug: bookSlug,
+          url: book.url
         },
         pages: bookPages.map((page, index) => ({
           ...page.data,  // Include all frontmatter data

--- a/src/COPYME_sample-ebook/index.html
+++ b/src/COPYME_sample-ebook/index.html
@@ -1,5 +1,6 @@
 ---
 title: "Sample eBook"
+shortTitle: "Sample eBook"
 layout: layout
 ---
 

--- a/src/_includes/sidebar.liquid
+++ b/src/_includes/sidebar.liquid
@@ -10,9 +10,11 @@
   {% assign currentBookSlug = page.filePathStem | split: "/" | slice: 2, 1 | join: "" %}
   {% for bookWithPages in collections.booksWithPages %}
     {% if bookWithPages.book.slug == currentBookSlug %}
-
       <div class="page-title">
-        <div>{{ bookWithPages.book.title }}</div>
+        <div>
+          <span class="full-title">{{ bookWithPages.book.title }}</span>
+          <span class="short-title">{{ bookWithPages.book.shortTitle | default: bookWithPages.book.title }}</span>
+        </div>
       </div>
       <div class="page-number">
         <div aria-label="Current page number">

--- a/src/ebooks/keeping-government-consistent/index.html
+++ b/src/ebooks/keeping-government-consistent/index.html
@@ -1,6 +1,7 @@
 ---
-title: "Keeping State Government Websites Consistent and Accessible"
-layout: layout
+title: "Keeping Government Software Development Consistent Across Teams"
+shortTitle: "Gov Software Teams"
+layout: cover
 ---
 
 {% include 'page.liquid' %}

--- a/src/ebooks/large-team-challenges/index.html
+++ b/src/ebooks/large-team-challenges/index.html
@@ -1,6 +1,7 @@
 ---
-title: "Challenges for Large Content Teams"
-layout: layout
+title: "Managing Large Team Challenges in Government Software Projects"
+shortTitle: "Team Management"
+layout: cover
 ---
 
 {% include 'page.liquid' %}

--- a/src/ebooks/over-structured-content/index.html
+++ b/src/ebooks/over-structured-content/index.html
@@ -1,5 +1,6 @@
 ---
 title: "5 Signs You’ve Over-structured Your Content"
+shortTitle: "Over-structured Content"
 layout: layout
 ---
 

--- a/src/ebooks/rogue-university/index.html
+++ b/src/ebooks/rogue-university/index.html
@@ -1,5 +1,6 @@
 ---
-title: "How to Keep Your University’s Websites from Going Rogue"
+title: "How to Keep Your University's Websites from Going Rogue"
+shortTitle: "University Websites"
 layout: layout
 ---
 

--- a/src/ebooks/why-your-cms-will-fail/index.html
+++ b/src/ebooks/why-your-cms-will-fail/index.html
@@ -1,5 +1,6 @@
 ---
 title: "Why Your CMS Project Will Fail"
+shortTitle: "CMS Failure"
 layout: layout
 ---
 

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -87,6 +87,23 @@ main {
       font-size: 1.25em;
       padding: 1em;
     }
+
+    .short-title {
+      display: none;
+    }
+  }
+}
+
+@media (height <= 800px) {
+  .sidebar .page-title {
+    div {
+      .full-title {
+        display: none;
+      }
+      .short-title {
+        display: inline;
+      }
+    }
   }
 }
 
@@ -520,11 +537,19 @@ p {
     flex-direction: row;
 
     .page-title {
-      transform: rotate(90deg);
+      transform: none;
+      width: auto;
 
       div {
-        overflow: hidden;
-        text-overflow: ellipsis;
+        transform: none;
+        padding: 1em;
+
+        .full-title {
+          display: none;
+        }
+        .short-title {
+          display: inline;
+        }
       }
     }
   }

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -94,7 +94,7 @@ main {
   }
 }
 
-@media (height <= 800px) {
+@media (height <= 920px) {
   .sidebar .page-title {
     div {
       .full-title {


### PR DESCRIPTION
Resolves #73

Add short titles for mobile/narrow viewports

- Added shortTitle field to book metadata in index.html files
- Updated .eleventy.js to include shortTitle in book collection data
- Modified sidebar.liquid to display shortTitle with fallback to full title
- Updated styles.scss to show shortTitle on narrow viewports (height <= 800px) and mobile (width <= 1440px)

This change improves readability of book titles in the sidebar when space is constrained, either due to narrow viewport height in desktop view or when the site switches to mobile layout. The shortTitle provides a more concise version while maintaining context.